### PR TITLE
Add description for Spotify-compatible

### DIFF
--- a/rss2.xml
+++ b/rss2.xml
@@ -7,6 +7,7 @@
     <itunes:subtitle></itunes:subtitle>
     <itunes:author>{{ config.author }}</itunes:author>
     <itunes:summary>{{ config.description | xml_escape }}</itunes:summary>
+    <description>{{ config.description | xml_escape }}</description>
     <itunes:owner>
       <itunes:name>{{ config.podcast.owner }}</itunes:name>
       <itunes:email>{{ config.podcast.email }}</itunes:email>


### PR DESCRIPTION
Spotify Podcast RSS requires description field for submitting.

ref: https://podcasters.spotify.com/terms/Spotify_Podcast_Delivery_Specification_v1.6.pdf

