### PR TITLE
Use link as guid

### DIFF
--- a/rss2.xml
+++ b/rss2.xml
@@ -27,7 +27,7 @@
       <itunes:summary>{{ post.excerpt | noControlChars | strip_html | xml_escape }}</itunes:summary>
       <itunes:image href="{{ config.podcast.url }}{{ post.image }}"/>
       <enclosure url="{{ config.podcast.url }}{{ post.media }}" length="{{ post.length }}" type="{{ post.mediatype }}"/>
-      <guid></guid>
+      <guid>{{ post.permalink }}</guid>
       <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
       <itunes:duration>{{ post.duration }}</itunes:duration>
       <psc:chapters version="1.2" xmlns:psc="http://podlove.org/simple-chapters">


### PR DESCRIPTION
Most podcast players would try to use guid as an unique identifier for podcast updates, and this tag is required for Spotify. Referring to other podcast providers, most of them would use permalink as the guid. This patch include such implementation in the rss.

<img width="993" alt="image" src="https://user-images.githubusercontent.com/2303500/98762208-868bf180-241a-11eb-9192-cb6867af4282.png">
